### PR TITLE
Update cisco-8000.ini

### DIFF
--- a/platform/checkout/cisco-8000.ini
+++ b/platform/checkout/cisco-8000.ini
@@ -1,3 +1,3 @@
 [module]
 repo=git@github.com:Cisco-8000-sonic/platform-cisco-8000.git
-ref=202205.2.2.8
+ref=202205.main.0.7


### PR DESCRIPTION
Why I did it
Release content for 8111-32EH-O:
	•	RDMA Support 
	•	L2: MAC Aging support

How I did it
Update platform version to 202205.main.0.7